### PR TITLE
Allow the `optional` field in MatchDto to be null

### DIFF
--- a/src/Challonge/DTO/MatchDto.php
+++ b/src/Challonge/DTO/MatchDto.php
@@ -28,7 +28,7 @@ class MatchDto extends DataTransferObject
     public ?string $open_graph_image_file_name;
     public ?string $open_graph_image_content_type;
     public ?string $open_graph_image_file_size;
-    public bool $optional;
+    public ?bool $optional;
     public ?int $player1_id;
     public bool $player1_is_prereq_match_loser;
     public ?int $player1_prereq_match_id;


### PR DESCRIPTION
If a tournament is configured to have a bronze medal match, the `optional` field for this match will be null instead of a boolean.