### PR TITLE
change datatype of toxic to bool

### DIFF
--- a/src/Challonge/DTO/Tournament.php
+++ b/src/Challonge/DTO/Tournament.php
@@ -104,7 +104,7 @@ class Tournament extends DataTransferObject
     public bool $team_convertable;
     public bool $group_stages_were_started;
     public ?string $team_size_range;
-    public ?string $toxic;
+    public ?bool $toxic;
     public ?bool $use_new_style;
     public array $optional_display_data;
 


### PR DESCRIPTION
I have managed to create a match that had the property toxic setted the first time, and i finnaly found out what this means (https://kb.challonge.com/en/article/why-is-my-tournament-flagged-as-toxic-sq3j7d/).

so i got the error:
```
Invalid type: expected `Reflex\Challonge\DTO\Tournament::toxic` to be of type `string`, instead got value `1`, which is boolean..
```
